### PR TITLE
Fix issue where multiple changes to the same model skipped later changes

### DIFF
--- a/change_summary.js
+++ b/change_summary.js
@@ -816,8 +816,9 @@
 
       var anyChanged = false;
       for (var prop in this.propertyObservers) {
-        anyChanged = anyChanged ||
-            this.checkPathValues(this.propertyObservers[prop], diff, oldValues);
+        anyChanged = this.checkPathValues(this.propertyObservers[prop],
+                                          diff,
+                                          oldValues) || anyChanged;
       }
       return anyChanged;
     },

--- a/test.js
+++ b/test.js
@@ -1328,3 +1328,29 @@ function testArrayTrackerNoProxiesEdits() {
   assertEditDistance(model, 7);
   observer.unobserveArray(model);
 }
+
+function testMultipleChangesAtOnce() {
+  var model = {
+    a: {b: 'ab'},
+    c: {d: 'cd'}
+  };
+
+  observer.observePath(model, 'a.b');
+  observer.observePath(model, 'c.d');
+  observer.deliver();
+
+  model.a = {b: 1};
+  model.c = {d: 2};
+
+  assertSummary({
+    object: model,
+    pathChanged: {
+      'a.b': 1,
+      'c.d': 2
+    },
+    oldValues: {
+      'a.b': 'ab',
+      'c.d': 'cd'
+    },
+  });
+}


### PR DESCRIPTION
ObjectTracker checkPathValues has side effects so we need to make sure it is
not skipped due to JS shortcutting logical or expressions.
