### PR TITLE
fix for use in strict mode

### DIFF
--- a/src/observe.js
+++ b/src/observe.js
@@ -1345,4 +1345,4 @@
   global.PathObserver = PathObserver;
   global.CompoundPathObserver = CompoundPathObserver;
   global.Path = Path;
-})(typeof global !== 'undefined' && global ? global : this);
+})(typeof global !== 'undefined' && global ? global : this || window);


### PR DESCRIPTION
When observe-js is included in a strict mode-enabled wrapper function, `this` is undefined thus the `global` variable in the observe-js module wrapper function is `undefined`. An exception is thrown on the `global.Number` line at the top (cannot access `Number` on `undefined`).

``` javascript
(function () {
  'use strict';

  // observe-js code here

  // application code here
}());
```
