### PR TITLE
fixes #70 -- move d8 specific code into d8_benchmark.js

### DIFF
--- a/benchmark/d8_benchmarks.js
+++ b/benchmark/d8_benchmarks.js
@@ -22,6 +22,21 @@ var setTimeout = function(callback) {
   callback();
 }
 
+var hasDebugForceFullDelivery = (function() {
+  try {
+    eval('%RunMicrotasks()');
+    return true;
+  } catch (ex) {
+    return false;
+  }
+})();
+
+if (hasDebugForceFullDelivery) {
+  Platform.performMicrotaskCheckpoint = function() {
+    eval('%RunMicrotasks()');
+  };
+}
+
 recordCount = 0;
 
 var alert = print;

--- a/src/observe.js
+++ b/src/observe.js
@@ -70,7 +70,7 @@
     // Firefox OS Apps do not allow eval. This feature detection is very hacky
     // but even if some other platform adds support for this function this code
     // will continue to work.
-    if (navigator.getDeviceStorage) {
+    if (typeof navigator != 'undefined' && navigator.getDeviceStorage) {
       return false;
     }
 
@@ -799,25 +799,11 @@
 
   var runningMicrotaskCheckpoint = false;
 
-  var hasDebugForceFullDelivery = hasObserve && hasEval && (function() {
-    try {
-      eval('%RunMicrotasks()');
-      return true;
-    } catch (ex) {
-      return false;
-    }
-  })();
-
   global.Platform = global.Platform || {};
 
   global.Platform.performMicrotaskCheckpoint = function() {
     if (runningMicrotaskCheckpoint)
       return;
-
-    if (hasDebugForceFullDelivery) {
-      eval('%RunMicrotasks()');
-      return;
-    }
 
     if (!collectObservers)
       return;


### PR DESCRIPTION
Also fixes the benchmark to work again on d8 ("navigator" was undefined). I ran it with:

``` sh
d8 --allow-natives-syntax ../src/observe.js benchmark.js observation_benchmark.js d8_benchmarks.js
```

The main reason for this change is to avoid an exception on startup in Chrome (eval %RunMicrotasks will fail).
