### PR TITLE
fix bug with rootObj optimization in observed sets

### DIFF
--- a/src/observe.js
+++ b/src/observe.js
@@ -390,7 +390,7 @@
           obj = obj[this[i - 1]];
         if (!isObject(obj))
           return;
-        observe(obj, this[0]);
+        observe(obj, this[i]);
       }
     },
 
@@ -663,14 +663,13 @@
     }
 
     var record = {
-      object: undefined,
       objects: objects,
+      get rootObject() { return rootObj; },
+      set rootObject(value) {
+        rootObj = value;
+        rootObjProps = {};
+      },
       open: function(obs, object) {
-        if (!rootObj) {
-          rootObj = object;
-          rootObjProps = {};
-        }
-
         observers.push(obs);
         observerCount++;
         obs.iterateObjects_(observe);
@@ -691,7 +690,9 @@
         rootObj = undefined;
         rootObjProps = undefined;
         observedSetCache.push(this);
-      }
+        if (lastObservedSet === this)
+          lastObservedSet = null;
+      },
     };
 
     return record;
@@ -700,9 +701,9 @@
   var lastObservedSet;
 
   function getObservedSet(observer, obj) {
-    if (!lastObservedSet || lastObservedSet.object !== obj) {
+    if (!lastObservedSet || lastObservedSet.rootObject !== obj) {
       lastObservedSet = observedSetCache.pop() || newObservedSet();
-      lastObservedSet.object = obj;
+      lastObservedSet.rootObject = obj;
     }
     lastObservedSet.open(observer, obj);
     return lastObservedSet;

--- a/tests/test.js
+++ b/tests/test.js
@@ -942,6 +942,26 @@ suite('PathObserver Tests', function() {
       done();
     });
   });
+
+  test('object cycle', function(done) {
+    var model = { a: {}, c: 1 };
+    model.a.b = model;
+
+    var called = 0;
+    new PathObserver(model, 'a.b.c').open(function() {
+      called++;
+    });
+
+    // This change should be detected, even though it's a change to the root
+    // object and isn't a change to `a`.
+    model.c = 42;
+
+    then(function() {
+      assert.equal(called, 1);
+      done();
+    });
+  });
+
 });
 
 


### PR DESCRIPTION
while investigating https://github.com/Polymer/polymer-dev/issues/101, I found two bugs with the rootObj optimization in observed sets:
- Models can have cycles, therefore, we may encounter the "root object" further down the path but not remember this fact. This leads to incorrectly failing to fire a change notification.
- At first, my new test only failed when run by itself, but passed in the full suite. This is because of a second bug: lastObservedSet can sometimes be the set we just closed. This leads to confusion about whether the observed set was closed or not, ultimately leaving it pointing at the wrong rootObj in its closure. I tried to mitigate this in two ways: instead of this.object and rootObj both tracking the same value, this is now handled explicitly in a setter to ensure they stay in sync. Also, if we close an observer make sure it is not still listed as the (alive) lastObservedSet.
