### PR TITLE
improve performance for template repeat over model objects with shared prototype

### DIFF
--- a/src/observe.js
+++ b/src/observe.js
@@ -608,6 +608,8 @@
 
   var observedSetCache = [];
 
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+
   function newObservedSet() {
     var observerCount = 0;
     var observers = [];
@@ -619,15 +621,24 @@
       if (!obj)
         return;
 
-      if (obj === rootObj)
+      var observeProto = true;
+      if (obj === rootObj) {
         rootObjProps[prop] = true;
+
+        // If we find the property on the root object, we can skip observing
+        // the prototype, which is expensive. This helps a common use case:
+        // when the user has <template repeat> over items that all share a
+        // prototype. See https://github.com/Polymer/polymer-dev/issues/101
+        observeProto = !hasOwnProperty.call(rootObj, prop);
+      }
 
       if (objects.indexOf(obj) < 0) {
         objects.push(obj);
         Object.observe(obj, callback);
       }
 
-      observe(Object.getPrototypeOf(obj), prop);
+      if (observeProto)
+        observe(Object.getPrototypeOf(obj), prop);
     }
 
     function allRootObjNonObservedProps(recs) {


### PR DESCRIPTION
This fixes the case presented in: https://github.com/Polymer/polymer-dev/issues/101

What is happening there is we have a bunch of paths inside a `<template repeat>` such as `{{model.path}}`. With polymer-expressions, the model for each repeated item has the same `__proto__`, which is the containing element, and we don't want every property set there to ping every item in the list. This seems to be the simplest thing that prevents the bug.

(Note: if the property is deleted from rootObj, we should get a change record from rootObj which causes us to iterate all objects again, and at that point, will observe the prototype because it is no longer an ownProperty of rootObj. That won't happen for polymer-expression scopes, but could happen in general.)
