### PR TITLE
allow import with module loaders

### DIFF
--- a/src/observe.js
+++ b/src/observe.js
@@ -1685,7 +1685,7 @@
 
   var expose = global;
 
-  if (typeof exports !== 'undefined' && !exports.nodeType) {
+  if (typeof window === 'undefined' && typeof exports !== 'undefined' && !exports.nodeType) {
     if (typeof module !== 'undefined' && module.exports) {
       exports = module.exports;
     }
@@ -1708,4 +1708,4 @@
   expose.Path = Path;
   expose.ObserverTransform = ObserverTransform;
   
-})(typeof global !== 'undefined' && global && typeof module !== 'undefined' && module ? global : this || window);
+})(window || global);


### PR DESCRIPTION
As mentioned here https://github.com/Polymer/polymer/issues/1236 `observe-js` has a problem when loaded with module loaders since the check for Node.js is to weak.

Also is there a reason for that?

``` js
typeof global !== 'undefined' && global && typeof module !== 'undefined' && module ? global : this || window
```

In general I would recommend not to use `this` in such cases because it's simply not predictable.
