### PR TITLE
Support defaultValue in Path.getValueFrom/PathObserver

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -224,6 +224,9 @@ suite('Path', function() {
     };
     assert.strictEqual(undefined, p3.getValueFrom(obj));
     assert.strictEqual(4, p2.getValueFrom(obj));
+
+    var defaultValue = 42;
+    assert.strictEqual(defaultValue, p3.getValueFrom(obj, defaultValue));
   });
 
   test('Path.setValueFrom', function() {


### PR DESCRIPTION
I was using [lodash](/lodash/lodash)'s [`_.get(object, path, defaultValue)](https://lodash.com/docs#get) to get keys at a given path but now that my project needs `Object.observe` capabilities, I want to keep this functionality consistent so I'd prefer to use `Path.getValueFrom(obj, defaultValue)`. Currently `observe-js` defaults to `undefined`; I preserved that functionality but allowed for an override to be passed in. It works like so:

```javascript
let path = Path.get('foo.bar');
let objA = { foo: {} };
let objB = { foo: { bar: undefined } };
let notFound = Symbol.for(404);

console.log(path.getValueFrom(objA, notFound)); // Symbol(404)
console.log(path.getValueFrom(objB, notFound)); // undefined

let observer = new PathObserver(objA, 'foo.bar', notFound);
observer.open(function(newValue) {
    console.log(newValue);
});
objA.foo.bar = 'baz'; // console logs baz
delete objA.foo.bar; // console logs Symbol(404)
```

I added a test for `Path.getValueFrom` but was uncertain where to put tests for `PathObserver`s with a `defaultValue` specified because there's an overwhelming amount of `PathObserver` related tests.